### PR TITLE
Deploy book to github pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,34 @@
+language: R
+sudo: required
+cache: packages
+
+r_packages:
+  - bookdown
+
+before_script:
+  - chmod +x ./_build.sh
+
+before_install:                           # Install Ruby and html-proofer
+  - rvm get stable --auto-dotfiles
+  - rvm install 2.3.3
+  - gem install html-proofer
+
+script:
+  - ./_build.sh
+  - htmlproofer ./docs 
+
+deploy:
+  provider: pages                         # Specify the gh-pages deployment method
+  skip_cleanup: true                      # Don't remove files
+  github_token: $GITHUB_TOKEN             # Set in travis-ci.org dashboard
+  local_dir: docs                         # Deploy the docs folder
+  on:
+    branch: master
+
+env:
+  global:
+    - NOKOGIRI_USE_SYSTEM_LIBRARIES=true  # Speed up the html-proofer
+
+notifications:
+  email: false
+

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,0 +1,6 @@
+Package: placeholder
+Type: Book
+Title: Does not matter.
+Version: 0.0.1
+Imports: bookdown, ggplot2
+Remotes: rstudio/bookdown

--- a/_bookdown.yml
+++ b/_bookdown.yml
@@ -2,3 +2,5 @@ book_filename: docSens
 language:
   label:
     fig: "Figur "
+output_dir: docs
+

--- a/_build.sh
+++ b/_build.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+Rscript -e "bookdown::render_book('index.Rmd', 'bookdown::gitbook')"


### PR DESCRIPTION
Om jeg husker rett må du gjøre følgende før dette vil fungere:

- Lage konto på Travis-CI.
- Lage en Token i github, som du legger inn i Travis-CI som GITHUB_TOKEN.
- Lag en branch som heter gh-pages.
- Gå inn i [settings](https://github.com/areedv/docSens/settings) og aktiver github-pages. Velg gh-pages som aktuell branch.

Travis-CI vil dytte html-filer, produsert av bookdown, til branchen gh-pages med `--force`. 

Jeg har aktivert htmlproofer, men den feiler akkurat nå med følgende feilmelding:
```
  *  image images/logo.svg does not have an alt attribute (line 106)
```
Det er derfor ikke sikkert sidene vil bygges, så mulig denne feilen må rettes før alt er ok. Jeg kan se på det. Man kan eventuelt skru av htmlproofer.
